### PR TITLE
Fix regenerator-runtime module

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ if (!hasGenerators) {
   regeneratorRuntime = (function () {
     var vm = require('vm');
     var ctx = vm.createContext({});
-    var file = require.resolve('regenerator/runtime.js');
+    var file = require.resolve('regenerator-runtime/runtime.js');
     vm.runInContext(fs.readFileSync(file, 'utf8'), ctx, file);
     return ctx.regeneratorRuntime;
   }());

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "barrage": "~1.1.0",
     "jade": "1.11.0",
     "promise": "~7.0.3",
+	"regenerator": "~0.8.46",
     "regenerator-runtime": "~0.9.5",
     "then-yield": "0.0.1",
     "with": "~5.0.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "barrage": "~1.1.0",
     "jade": "1.11.0",
     "promise": "~7.0.3",
-    "regenerator": "~0.8.30",
+    "regenerator-runtime": "~0.9.5",
     "then-yield": "0.0.1",
     "with": "~5.0.0"
   },


### PR DESCRIPTION
runtime.js was moved into a separate module called regenerator-runtime.

The provided version of regenerator, unfortunately prints a warning about the depreciation when you attempt to use runtime.js, `console.log` isn't available inside a vm context so the process crashes.  If it wasn't inside a vm context then it would have continued to work.

Changing the project to use the regenerator-runtime module solves the problem as the warning is no longer printed.
