### PR TITLE
updated uglify-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "mocha": "*",
     "should": "~3.1.2",
-    "uglify-js": "~2.4.12",
+    "uglify-js": "2.4.24",
     "mocha-as-promised": "~2.0.0",
     "coffee-script": "~1.7.1",
     "less": "~1.6.3",


### PR DESCRIPTION
Needed to force minor point update to prevent an alert from the Node security project. I realise that npm should have pulled a later version with the `~` but it didn't. Feel free to close this if you don't want to lock to a specific version of uglify. 